### PR TITLE
removed .c_str() on SHA512 hashing function

### DIFF
--- a/SHA512CryptoServiceProvider.cpp
+++ b/SHA512CryptoServiceProvider.cpp
@@ -131,8 +131,12 @@ void SHA512CryptoServiceProvider::ProcessBlock(const int64 *Message, int64 *H)
 */
 std::string SHA512CryptoServiceProvider::Hashing(std::string inputMessage)
 {
-    const char* mess = inputMessage.c_str();
-    int inputMessageLength = strlen(mess);
+    const char* mess;
+    int inputMessageLength = inputMessage.length();
+    for (int i = 0; i < inputMessageLength; i++)
+    {
+        mess += inputMessage[i];
+    }
 
     int64 intermediateLength, K, messageLength;
 


### PR DESCRIPTION
Hi there,

first thanks for sharing your code on github, it saved me a lot of time.
But I was always wondering why nearly every SHA512 C++ implementation calculated a wrong hash for my input. So I digged a bit deeper and noticed that the std::string.c_str() function will cut off my binary input.
According to it's documentation the function is looking for a null terminator ('\0').
So my input
`string = { 0x01, 0x00, 0x02, 0x00, 0x03 };`
would be shortened to
`string = { 0x01 }`
after using the .c_str() function.

So I removed .c_str() and built a for-loop to read every single char of the input. Don't know if this is best practice, but it works. :)

Have a nice weekend.


With best regards

Johnny